### PR TITLE
Fixes, optimizations and modernization

### DIFF
--- a/autoloader.php
+++ b/autoloader.php
@@ -1,2 +1,3 @@
 <?php
-require_once 'vendor/autoload.php';
+
+require_once './vendor/autoload.php';

--- a/bin/peg
+++ b/bin/peg
@@ -5,4 +5,4 @@ require __DIR__ . '/../autoloader.php';
 
 use hafriedlander\Peg\Compiler;
 
-Compiler::cli($_SERVER['argv']);
+Compiler::cli($argv);

--- a/bin/tests
+++ b/bin/tests
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cd $(dirname $0)/..
+
+./vendor/bin/phpunit ./tests

--- a/composer.json
+++ b/composer.json
@@ -39,5 +39,8 @@
             "hafriedlander\\Peg": "lib"
         }
     },
-    "bin": ["bin/peg"]
+    "bin": ["bin/peg"],
+    "require-dev": {
+        "phpunit/phpunit": "^6.5"
+    }
 }

--- a/lib/hafriedlander/Peg/Compiler.php
+++ b/lib/hafriedlander/Peg/Compiler.php
@@ -47,9 +47,9 @@ class Compiler {
 	static function compile( $string ) {
 		static $rx = '@
 			^([\x20\t]*)/\*!\* (?:[\x20\t]*(!?\w*))?   # Start with some indent, a comment with the special marker, then an optional name
-			((?:[^*]|\*[^/])*?)                        # Any amount of "a character that isnt a star, or a star not followed by a /
+			(.*)                                       # Any character
 			\*/                                        # The comment end
-		@mx';
+		@smx';
 
 		return preg_replace_callback( $rx, array( __CLASS__, 'create_parser' ), $string ) ;
 	}

--- a/lib/hafriedlander/Peg/Compiler.php
+++ b/lib/hafriedlander/Peg/Compiler.php
@@ -4,11 +4,11 @@ namespace hafriedlander\Peg;
 
 class Compiler {
 
-	static $parsers = array();
+	static $parsers = [];
 
-	static $debug = false;
+	static $debug = \false;
 
-	static $currentClass = null;
+	static $currentClass = \null;
 
 	static function create_parser( $match ) {
 		/* We allow indenting of the whole rule block, but only to the level of the comment start's indent */
@@ -30,9 +30,9 @@ class Compiler {
 						'/*',
 						'WARNING: This file has been machine generated. Do not edit it, or your changes will be overwritten next time it is compiled.',
 						'*/'
-					)) . PHP_EOL;
+					)) .\PHP_EOL;
 				case '!debug':
-					self::$debug = true;
+					self::$debug = \true;
 					return '';
 			}
 

--- a/lib/hafriedlander/Peg/Compiler/PHPBuilder.php
+++ b/lib/hafriedlander/Peg/Compiler/PHPBuilder.php
@@ -9,28 +9,28 @@ class PHPBuilder {
 	}
 
 	function __construct() {
-		$this->lines = array() ;
+		$this->lines = [] ;
 	}
 
 	function l() {
-		foreach ( func_get_args() as $lines ) {
+		foreach ( \func_get_args() as $lines ) {
 			if ( !$lines ) continue ;
 
 			if ( is_string( $lines ) ) $lines = preg_split( '/\r\n|\r|\n/', $lines ) ;
 			if ( !$lines ) continue ;
 
 			if ( $lines instanceof PHPBuilder ) $lines = $lines->lines ;
-			else                                $lines = array_map( 'ltrim', $lines ) ;
+			else                                $lines = \array_map( 'ltrim', $lines ) ;
 			if ( !$lines ) continue ;
 
-			$this->lines = array_merge( $this->lines, $lines ) ;
+			$this->lines = \array_merge( $this->lines, $lines ) ;
 		}
 		return $this ;
 	}
 
 	function b() {
-		$args = func_get_args() ;
-		$entry = array_shift( $args ) ;
+		$args = \func_get_args() ;
+		$entry = \array_shift( $args ) ;
 
 		$block = new PHPBuilder() ;
 		call_user_func_array( array( $block, 'l' ), $args ) ;
@@ -40,41 +40,41 @@ class PHPBuilder {
 		return $this ;
 	}
 
-	function replace( $replacements, &$array = NULL ) {
-		if ( $array === NULL ) {
+	function replace( $replacements, &$array = \null ) {
+		if ( $array === \null ) {
 			unset( $array ) ;
 			$array =& $this->lines ;
 		}
 
 		$i = 0 ;
-		while ( $i < count( $array ) ) {
+		while ( $i < \count( $array ) ) {
 
 			/* Recurse into blocks */
-			if ( is_array( $array[$i] ) ) {
+			if ( \is_array( $array[$i] ) ) {
 				$this->replace( $replacements, $array[$i][1] ) ;
 
-				if ( count( $array[$i][1] ) == 0 ) {
-					$nextelse = isset( $array[$i+1] ) && is_array( $array[$i+1] ) && preg_match( '/^\s*else\s*$/i', $array[$i+1][0] ) ;
+				if ( \count( $array[$i][1] ) == 0 ) {
+					$nextelse = isset( $array[$i+1] ) && \is_array( $array[$i+1] ) && \preg_match( '/^\s*else\s*$/i', $array[$i+1][0] ) ;
 
-					$delete = preg_match( '/^\s*else\s*$/i', $array[$i][0] ) ;
-					$delete = $delete || ( preg_match( '/^\s*if\s*\(/i', $array[$i][0] ) && !$nextelse ) ;
+					$delete = \preg_match( '/^\s*else\s*$/i', $array[$i][0] ) ;
+					$delete = $delete || ( \preg_match( '/^\s*if\s*\(/i', $array[$i][0] ) && !$nextelse ) ;
 
 					if ( $delete ) {
 						// Is this always safe? Not if the expression has side-effects.
 						// print "/* REMOVING EMPTY BLOCK: " . $array[$i][0] . "*/\n" ;
-						array_splice( $array, $i, 1 ) ;
+						\array_splice( $array, $i, 1 ) ;
 						continue ;
 					}
 				}
 			}
 
-			/* Handle replacing lines with NULL to remove, or string, array of strings or PHPBuilder to replace */
+			/* Handle replacing lines with \null to remove, or string, array of strings or PHPBuilder to replace */
 			else {
-				if ( array_key_exists( $array[$i], $replacements ) ) {
+				if ( \array_key_exists( $array[$i], $replacements ) ) {
 					$rep = $replacements[$array[$i]] ;
 
-					if ( $rep === NULL ) {
-						array_splice( $array, $i, 1 ) ;
+					if ( $rep === \null ) {
+						\array_splice( $array, $i, 1 ) ;
 						continue ;
 					}
 
@@ -86,8 +86,8 @@ class PHPBuilder {
 
 					if ( $rep instanceof PHPBuilder ) $rep = $rep->lines ;
 
-					if ( is_array( $rep ) ) {
-						array_splice( $array, $i, 1, $rep ) ; $i += count( $rep ) + 1 ;
+					if ( \is_array( $rep ) ) {
+						\array_splice( $array, $i, 1, $rep ) ; $i += \count( $rep ) + 1 ;
 						continue ;
 					}
 
@@ -101,17 +101,17 @@ class PHPBuilder {
 		return $this ;
 	}
 
-	function render( $array = NULL, $indent = "" ) {
-		if ( $array === NULL ) $array = $this->lines ;
+	function render( $array = \null, $indent = "" ) {
+		if ( $array === \null ) $array = $this->lines ;
 
-		$out = array() ;
+		$out = [] ;
 		foreach( $array as $line ) {
-			if ( is_array( $line ) ) {
+			if ( \is_array( $line ) ) {
 				list( $entry, $block ) = $line ;
 				$str = $this->render( $block, $indent . "\t" ) ;
 
-				if ( strlen( $str ) < 40 ) {
-					$out[] = $indent . $entry . ' { ' . ltrim( $str ) . ' }' ;
+				if ( \strlen( $str ) < 40 ) {
+					$out[] = $indent . $entry . ' { ' . \ltrim( $str ) . ' }' ;
 				}
 				else {
 					$out[] = $indent . $entry . ' {' ;
@@ -124,6 +124,6 @@ class PHPBuilder {
 			}
 		}
 
-		return implode( PHP_EOL, $out ) ;
+		return \implode(\PHP_EOL, $out ) ;
 	}
 }

--- a/lib/hafriedlander/Peg/Compiler/PHPWriter.php
+++ b/lib/hafriedlander/Peg/Compiler/PHPWriter.php
@@ -14,10 +14,10 @@ class PHPWriter {
 	}
 
 	function function_name( $str ) {
-		$str = preg_replace( '/-/', '_', $str ) ;
-		$str = preg_replace( '/\$/', 'DLR', $str ) ;
-		$str = preg_replace( '/\*/', 'STR', $str ) ;
-		$str = preg_replace( '/[^\w]+/', '', $str ) ;
+		$str = \preg_replace( '/-/', '_', $str ) ;
+		$str = \preg_replace( '/\$/', 'DLR', $str ) ;
+		$str = \preg_replace( '/\*/', 'STR', $str ) ;
+		$str = \preg_replace( '/[^\w]+/', '', $str ) ;
 		return $str ;
 	}
 
@@ -29,7 +29,7 @@ class PHPWriter {
 		);
 	}
 
-	function restore( $id, $remove = FALSE ) {
+	function restore( $id, $remove = \false ) {
 		$code = PHPBuilder::build()
 			->l(
 			'$result = $res'.$id.';',
@@ -44,7 +44,7 @@ class PHPWriter {
 		return $code ;
 	}
 
-	function match_fail_conditional( $on, $match = NULL, $fail = NULL ) {
+	function match_fail_conditional( $on, $match = \null, $fail = \null ) {
 		return PHPBuilder::build()
 			->b( 'if (' . $on . ')',
 			$match,
@@ -61,19 +61,19 @@ class PHPWriter {
 
 		return PHPBuilder::build()
 			->l(
-			'$'.$id.' = NULL;'
+			'$'.$id.' = \null;'
 		)
 			->b( 'do',
 			$code->replace(array(
-				'MBREAK' => '$'.$id.' = TRUE; break;',
-				'FBREAK' => '$'.$id.' = FALSE; break;'
+				'MBREAK' => '$'.$id.' = \true; break;',
+				'FBREAK' => '$'.$id.' = \false; break;'
 			))
 		)
 			->l(
 			'while(0);'
 		)
-			->b( 'if( $'.$id.' === TRUE )', 'MATCH' )
-			->b( 'if( $'.$id.' === FALSE)', 'FAIL'  )
+			->b( 'if( $'.$id.' === \true )', 'MATCH' )
+			->b( 'if( $'.$id.' === \false)', 'FAIL'  )
 			;
 	}
 }

--- a/lib/hafriedlander/Peg/Compiler/Rule.php
+++ b/lib/hafriedlander/Peg/Compiler/Rule.php
@@ -135,7 +135,7 @@ class Rule extends PHPWriter {
 		((\\\\\\\\)*\\\\/) # Escaped \/, making sure to catch all the \\ first, so that we dont think \\/ is an escaped /
 		|
 		[^/]               # Anything except /
-	)*/@xu' ;
+	)*/[a-zA-Z]*@xu' ;
 
 	function tokenize( $str, &$tokens, $o = 0 ) {
 		$length = strlen($str);
@@ -260,7 +260,7 @@ class Rule extends PHPWriter {
 						return $o ;
 
 					default:
-						user_error( "Can't parser $c - attempting to skip", E_USER_WARNING ) ;
+						user_error( "Can't parse '$c' - attempting to skip", E_USER_WARNING ) ;
 				}
 			}
 		}

--- a/lib/hafriedlander/Peg/Compiler/Rule.php
+++ b/lib/hafriedlander/Peg/Compiler/Rule.php
@@ -52,17 +52,17 @@ class Rule extends PHPWriter {
 		$this->lines = $lines;
 
 		// Find the first line (if any) that's an attached function definition. Can skip first line (unless this block is malformed)
-		for ($i = 1; $i < count($lines); $i++) {
-			if (preg_match(self::$function_rx, $lines[$i])) break;
+		for ($i = 1; $i < \count($lines); $i++) {
+			if (\preg_match(self::$function_rx, $lines[$i])) break;
 		}
 
 		// Then split into the two parts
-		$spec = array_slice($lines, 0, $i);
-		$funcs = array_slice($lines, $i);
+		$spec = \array_slice($lines, 0, $i);
+		$funcs = \array_slice($lines, $i);
 
 		// Parse out the spec
-		$spec = implode("\n", $spec);
-		if (!preg_match(self::$rule_rx, $spec, $specmatch)) user_error('Malformed rule spec ' . $spec, E_USER_ERROR);
+		$spec = \implode("\n", $spec);
+		if (!\preg_match(self::$rule_rx, $spec, $specmatch)) user_error('Malformed rule spec ' . $spec, E_USER_ERROR);
 
 		$this->name = $specmatch['name'];
 
@@ -71,13 +71,13 @@ class Rule extends PHPWriter {
 			if (!$this->extends) user_error('Extended rule '.$specmatch['extends'].' is not defined before being extended', E_USER_ERROR);
 		}
 
-		$this->arguments = array();
+		$this->arguments = [];
 
 		if ($specmatch['arguments']) {
-			preg_match_all(self::$argument_rx, $specmatch['arguments'], $arguments, PREG_SET_ORDER);
+			\preg_match_all(self::$argument_rx, $specmatch['arguments'], $arguments, \PREG_SET_ORDER);
 
 			foreach ($arguments as $argument){
-				$this->arguments[trim($argument[1])] = trim($argument[2]);
+				$this->arguments[\trim($argument[1])] = \trim($argument[2]);
 			}
 		}
 
@@ -90,16 +90,16 @@ class Rule extends PHPWriter {
 		else {
 			if (!$this->extends) user_error('Replace matcher, but not on an extends rule', E_USER_ERROR);
 
-			$this->replacements = array();
-			preg_match_all(self::$replacement_rx, $specmatch['rule'], $replacements, PREG_SET_ORDER);
+			$this->replacements = [];
+			\preg_match_all(self::$replacement_rx, $specmatch['rule'], $replacements, \PREG_SET_ORDER);
 
 			$rule = $this->extends->rule;
 
 			foreach ($replacements as $replacement) {
-				$search = trim($replacement[1]);
-				$replace = trim($replacement[3]); if ($replace == "''" || $replace == '""') $replace = "";
+				$search = \trim($replacement[1]);
+				$replace = \trim($replacement[3]); if ($replace == "''" || $replace == '""') $replace = "";
 
-				$rule = str_replace($search, ' '.$replace.' ', $rule);
+				$rule = \str_replace($search, ' '.$replace.' ', $rule);
 			}
 
 			$this->rule = $rule;
@@ -108,27 +108,27 @@ class Rule extends PHPWriter {
 
 		// Parse out the functions
 
-		$this->functions = array() ;
+		$this->functions = [] ;
 
-		$active_function = NULL ;
+		$active_function = \null ;
 
 		foreach( $funcs as $line ) {
 			/* Handle function definitions */
-			if ( preg_match( self::$function_rx, $line, $func_match, 0 ) ) {
+			if ( \preg_match( self::$function_rx, $line, $func_match, 0 ) ) {
 				$active_function = $func_match[1];
-				$this->functions[$active_function] = $func_match[2] . PHP_EOL;
+				$this->functions[$active_function] = $func_match[2] . \PHP_EOL;
 			}
-			else $this->functions[$active_function] .= $line . PHP_EOL ;
+			else $this->functions[$active_function] .= $line . \PHP_EOL ;
 		}
 	}
 
 	/* Manual parsing, because we can't bootstrap ourselves yet */
 	function parse_rule() {
-		$rule = trim( $this->rule ) ;
+		$rule = \trim( $this->rule ) ;
 
-		$tokens = array() ;
+		$tokens = [] ;
 		$this->tokenize( $rule, $tokens ) ;
-		$this->parsed = ( count( $tokens ) == 1 ? array_pop( $tokens ) : new Token\Sequence( $tokens ) ) ;
+		$this->parsed = ( \count( $tokens ) == 1 ? \array_pop( $tokens ) : new Token\Sequence( $tokens ) ) ;
 	}
 
 	static $rx_rx = '@\G/(
@@ -144,70 +144,70 @@ class Rule extends PHPWriter {
 		while ( $o < $length ) {
 
 			/* Absorb white-space */
-			if ( preg_match( '/\G\s+/', $str, $match, 0, $o ) ) {
+			if ( \preg_match( '/\G\s+/', $str, $match, 0, $o ) ) {
 				$o += strlen( $match[0] ) ;
 			}
 			/* Handle expression labels */
-			elseif ( preg_match( '/\G(\w*):/', $str, $match, 0, $o ) ) {
+			elseif ( \preg_match( '/\G(\w*):/', $str, $match, 0, $o ) ) {
 				$pending->set( 'tag', isset( $match[1] ) ? $match[1] : '' ) ;
 				$o += strlen( $match[0] ) ;
 			}
 			/* Handle descent token */
-			elseif ( preg_match( '/\G[\w-]+/', $str, $match, 0, $o ) ) {
+			elseif ( \preg_match( '/\G[\w-]+/', $str, $match, 0, $o ) ) {
 				$tokens[] = $t = new Token\Recurse( $match[0] ) ;
 				$pending->apply_if_present( $t ) ;
 				$o += strlen( $match[0] ) ;
 			}
 			/* Handle " quoted literals */
-			elseif ( preg_match( '/\G"[^"]*"/', $str, $match, 0, $o ) ) {
+			elseif ( \preg_match( '/\G"[^"]*"/', $str, $match, 0, $o ) ) {
 				$tokens[] = $t = new Token\Literal( $match[0] ) ;
 				$pending->apply_if_present( $t ) ;
 				$o += strlen( $match[0] ) ;
 			}
 			/* Handle ' quoted literals */
-			elseif ( preg_match( "/\G'[^']*'/", $str, $match, 0, $o ) ) {
+			elseif ( \preg_match( "/\G'[^']*'/", $str, $match, 0, $o ) ) {
 				$tokens[] = $t = new Token\Literal( $match[0] ) ;
 				$pending->apply_if_present( $t ) ;
 				$o += strlen( $match[0] ) ;
 			}
 			/* Handle regexs */
-			elseif ( preg_match( self::$rx_rx, $str, $match, 0, $o ) ) {
+			elseif ( \preg_match( self::$rx_rx, $str, $match, 0, $o ) ) {
 				$tokens[] = $t = new Token\Regex( $match[0] ) ;
 				$pending->apply_if_present( $t ) ;
 				$o += strlen( $match[0] ) ;
 			}
 			/* Handle $ call literals */
-			elseif ( preg_match( '/\G\$(\w+)/', $str, $match, 0, $o ) ) {
+			elseif ( \preg_match( '/\G\$(\w+)/', $str, $match, 0, $o ) ) {
 				$tokens[] = $t = new Token\ExpressionedRecurse( $match[1] ) ;
 				$pending->apply_if_present( $t ) ;
 				$o += strlen( $match[0] ) ;
 			}
 			/* Handle flags */
-			elseif ( preg_match( '/\G\@(\w+)/', $str, $match, 0, $o ) ) {
-				$l = count( $tokens ) - 1 ;
+			elseif ( \preg_match( '/\G\@(\w+)/', $str, $match, 0, $o ) ) {
+				$l = \count( $tokens ) - 1 ;
 				$o += strlen( $match[0] ) ;
 				user_error( "TODO: Flags not currently supported", E_USER_WARNING ) ;
 			}
 			/* Handle control tokens */
 			else {
 				$c = substr( $str, $o, 1 ) ;
-				$l = count( $tokens ) - 1 ;
+				$l = \count( $tokens ) - 1 ;
 				$o += 1 ;
 				switch( $c ) {
 					case '?':
 						$tokens[$l]->quantifier = array('min' => 0, 'max' => 1);
 						break ;
 					case '*':
-						$tokens[$l]->quantifier = array('min' => 0, 'max' => null);
+						$tokens[$l]->quantifier = array('min' => 0, 'max' => \null);
 						break ;
 					case '+':
-						$tokens[$l]->quantifier = array('min' => 1, 'max' => null);
+						$tokens[$l]->quantifier = array('min' => 1, 'max' => \null);
 						break ;
 					case '{':
-						if (preg_match('/\G\{([0-9]+)(,([0-9]*))?\}/', $str, $matches, 0, $o - 1)) {
+						if (\preg_match('/\G\{([0-9]+)(,([0-9]*))?\}/', $str, $matches, 0, $o - 1)) {
 							$min = $max = (int) $matches[1];
 							if(isset($matches[2])) {
-								$max = $matches[3] ? (int) $matches[3] : null;
+								$max = $matches[3] ? (int) $matches[3] : \null;
 							}
 							$tokens[$l]->quantifier = array('min' => $min, 'max' => $max);
 							$o += strlen($matches[0]) - 1;
@@ -231,15 +231,15 @@ class Rule extends PHPWriter {
 
 					case '[':
 					case ']':
-						$tokens[] = new Token\Whitespace( FALSE ) ;
+						$tokens[] = new Token\Whitespace( \false ) ;
 						break ;
 					case '<':
 					case '>':
-						$tokens[] = new Token\Whitespace( TRUE ) ;
+						$tokens[] = new Token\Whitespace( \true ) ;
 						break ;
 
 					case '(':
-						$subtokens = array() ;
+						$subtokens = [] ;
 						$o = $this->tokenize( $str, $subtokens, $o ) ;
 						$tokens[] = $t = new Token\Sequence( $subtokens ) ; $pending->apply_if_present( $t ) ;
 						break ;
@@ -248,11 +248,11 @@ class Rule extends PHPWriter {
 
 					case '|':
 						$option1 = $tokens ;
-						$option2 = array() ;
+						$option2 = [] ;
 						$o = $this->tokenize( $str, $option2, $o ) ;
 
-						$option1 = (count($option1) == 1) ? $option1[0] : new Token\Sequence( $option1 );
-						$option2 = (count($option2) == 1) ? $option2[0] : new Token\Sequence( $option2 );
+						$option1 = (\count($option1) == 1) ? $option1[0] : new Token\Sequence( $option1 );
+						$option2 = (\count($option2) == 1) ? $option2[0] : new Token\Sequence( $option2 );
 
 						$pending->apply_if_present( $option2 ) ;
 
@@ -275,17 +275,17 @@ class Rule extends PHPWriter {
 		$function_name = $this->function_name( $this->name ) ;
 
 		// Build the typestack
-		$typestack = array(); $class=$this;
+		$typestack = []; $class=$this;
 		do {
 			$typestack[] = $this->function_name($class->name);
 		}
 		while($class = $class->extends);
 
-		$typestack = "array('" . implode("','", $typestack) . "')";
+		$typestack = "array('" . \implode("','", $typestack) . "')";
 
 		// Build an array of additional arguments to add to result node (if any)
 		if (empty($this->arguments)) {
-			$arguments = 'null';
+			$arguments = '\null';
 		}
 		else {
 			$arguments = "array(";
@@ -297,23 +297,23 @@ class Rule extends PHPWriter {
 
 		$match->l("protected \$match_{$function_name}_typestack = $typestack;");
 
-		$match->b( "function match_{$function_name} (\$stack = array())",
+		$match->b( "function match_{$function_name} (\$stack = [])",
 			'$matchrule = "'.$function_name.'"; $result = $this->construct($matchrule, $matchrule, '.$arguments.');',
 			$this->parsed->compile()->replace(array(
 				'MATCH' => 'return $this->finalise($result);',
-				'FAIL' => 'return FALSE;'
+				'FAIL' => 'return \false;'
 			))
 		);
 
-		$functions = array() ;
+		$functions = [] ;
 		foreach( $this->functions as $name => $function ) {
-			$function_name = $this->function_name( preg_match( '/^_/', $name ) ? $this->name.$name : $this->name.'_'.$name ) ;
-			$functions[] = implode( PHP_EOL, array(
+			$function_name = $this->function_name( \preg_match( '/^_/', $name ) ? $this->name.$name : $this->name.'_'.$name ) ;
+			$functions[] = \implode( \PHP_EOL, array(
 				'public function ' . $function_name . ' ' . $function
 			));
 		}
 
 		// print_r( $match ) ; return '' ;
-		return $match->render(NULL, $indent) . PHP_EOL . PHP_EOL . implode( PHP_EOL, $functions ) ;
+		return $match->render(\null, $indent) . \PHP_EOL . \PHP_EOL . \implode( \PHP_EOL, $functions ) ;
 	}
 }

--- a/lib/hafriedlander/Peg/Compiler/Rule/PendingState.php
+++ b/lib/hafriedlander/Peg/Compiler/Rule/PendingState.php
@@ -10,20 +10,20 @@ namespace hafriedlander\Peg\Compiler\Rule;
  */
 class PendingState {
 	function __construct() {
-		$this->what = NULL ;
+		$this->what = \null ;
 	}
 
-	function set( $what, $val = TRUE ) {
+	function set( $what, $val = \true ) {
 		$this->what = $what ;
 		$this->val = $val ;
 	}
 
 	function apply_if_present( $on ) {
-		if ( $this->what !== NULL ) {
+		if ( $this->what !== \null ) {
 			$what = $this->what ;
 			$on->$what = $this->val ;
 
-			$this->what = NULL ;
+			$this->what = \null ;
 		}
 	}
 }

--- a/lib/hafriedlander/Peg/Compiler/RuleSet.php
+++ b/lib/hafriedlander/Peg/Compiler/RuleSet.php
@@ -3,22 +3,22 @@
 namespace hafriedlander\Peg\Compiler;
 
 class RuleSet {
-	public $rules = array();
+	public $rules = [];
 
 	function addRule($indent, $lines, &$out) {
 		$rule = new Rule($this, $lines) ;
 		$this->rules[$rule->name] = $rule;
 
-		$out[] = $indent . '/* ' . $rule->name . ':' . $rule->rule . ' */' . PHP_EOL ;
+		$out[] = $indent . '/* ' . $rule->name . ':' . $rule->rule . ' */' .\PHP_EOL ;
 		$out[] = $rule->compile($indent) ;
-		$out[] = PHP_EOL ;
+		$out[] =\PHP_EOL ;
 	}
 
 	function compile($indent, $rulestr) {
 		$indentrx = '@^'.preg_quote($indent).'@';
 
-		$out = array();
-		$block = array();
+		$out = [];
+		$block = [];
 
 		foreach (preg_split('/\r\n|\r|\n/', $rulestr) as $line) {
 			// Ignore blank lines

--- a/lib/hafriedlander/Peg/Compiler/Token.php
+++ b/lib/hafriedlander/Peg/Compiler/Token.php
@@ -17,19 +17,19 @@ namespace hafriedlander\Peg\Compiler;
  */
 abstract class Token extends PHPWriter {
 
-	public $quantifier = NULL;
+	public $quantifier = \null;
 
-	public $positive_lookahead = FALSE ;
-	public $negative_lookahead = FALSE ;
+	public $positive_lookahead = \false ;
+	public $negative_lookahead = \false ;
 
-	public $silent = FALSE ;
+	public $silent = \false ;
 
-	public $tag = FALSE ;
+	public $tag = \false ;
 
 	public $type ;
 	public $value ;
 
-	function __construct( $type, $value = NULL ) {
+	function __construct( $type, $value = \null ) {
 		$this->type = $type ;
 		$this->value = $value ;
 	}
@@ -46,10 +46,10 @@ abstract class Token extends PHPWriter {
 			if (0 === $q['min'] && 1 === $q['max']) {
 				// optional: ? || {0,1}
 				$code = $this->optional($code, $id);
-			} else if (0 === $q['min'] && null === $q['max']) {
+			} else if (0 === $q['min'] && \null === $q['max']) {
 				// zero or more: * || {0,}
 				$code = $this->zero_or_more($code, $id);
-			} else if (null === $q['max']) {
+			} else if (\null === $q['max']) {
 				// n or more: + || {n,}
 				$code = $this->n_or_more($code, $id, $q['min']);
 			} else {
@@ -93,13 +93,13 @@ abstract class Token extends PHPWriter {
 				$code->replace(array(
 					'MATCH' => PHPBuilder::build()
 						->l(
-						'$subres = $result; $result = array_pop($stack);',
+						'$subres = $result; $result = \array_pop($stack);',
 						'$this->store( $result, $subres, \''.$this->tag.'\' );',
 						'MATCH'
 					),
 					'FAIL' => PHPBuilder::build()
 						->l(
-						'$result = array_pop($stack);',
+						'$result = \array_pop($stack);',
 						'FAIL'
 					)
 				)));
@@ -112,18 +112,18 @@ abstract class Token extends PHPWriter {
 	{
 		return PHPBuilder::build()->l(
 			$this->save($id),
-			$code->replace(array('FAIL' => $this->restore($id,true)))
+			$code->replace(array('FAIL' => $this->restore($id,\true)))
 		);
 	}
 
 	protected function zero_or_more($code, $id)
 	{
 		return PHPBuilder::build()->b(
-			'while (true)',
+			'while (\true)',
 			$this->save($id),
 			$code->replace(array(
-				'MATCH' => NULL,
-				'FAIL' => $this->restore($id, true)->l('break;')
+				'MATCH' => \null,
+				'FAIL' => $this->restore($id, \true)->l('break;')
 			))
 		)->l('MATCH');
 	}
@@ -133,11 +133,11 @@ abstract class Token extends PHPWriter {
 		return PHPBuilder::build()->l(
 			'$count = 0;'
 		)->b(
-			'while (true)',
+			'while (\true)',
 			$this->save($id),
 			$code->replace(array(
-				'MATCH' => NULL,
-				'FAIL' => $this->restore($id, true)->l('break;')
+				'MATCH' => \null,
+				'FAIL' => $this->restore($id, \true)->l('break;')
 			)),
 			'$count++;'
 		)->b(
@@ -159,8 +159,8 @@ abstract class Token extends PHPWriter {
 			'while ($count < '.$max.')',
 			$this->save($id),
 			$code->replace(array(
-				'MATCH' => NULL,
-				'FAIL' => $this->restore($id, true)->l('break;')
+				'MATCH' => \null,
+				'FAIL' => $this->restore($id, \true)->l('break;')
 			)),
 			'$count++;'
 		)->b(

--- a/lib/hafriedlander/Peg/Compiler/Token/Literal.php
+++ b/lib/hafriedlander/Peg/Compiler/Token/Literal.php
@@ -6,13 +6,13 @@ use hafriedlander\Peg\Compiler\PHPBuilder;
 
 class Literal extends Expressionable {
 	function __construct( $value ) {
-		parent::__construct( 'literal', "'" . substr($value,1,-1) . "'" );
+		parent::__construct( 'literal', "'" . \substr($value,1,-1) . "'" );
 	}
 
 	function match_code( $value ) {
 		// We inline single-character matches for speed
-		if ( !$this->contains_expression($value) && strlen( eval( 'return '. $value . ';' ) ) == 1 ) {
-			return $this->match_fail_conditional( 'substr($this->string,$this->pos,1) == '.$value,
+		if ( !$this->contains_expression($value) && \strlen( eval( 'return '. $value . ';' ) ) === 1 ) {
+			return $this->match_fail_conditional( '\substr($this->string,$this->pos,1) == '.$value,
 				PHPBuilder::build()->l(
 					'$this->pos += 1;',
 					$this->set_text($value)

--- a/lib/hafriedlander/Peg/Compiler/Token/Literal.php
+++ b/lib/hafriedlander/Peg/Compiler/Token/Literal.php
@@ -12,7 +12,7 @@ class Literal extends Expressionable {
 	function match_code( $value ) {
 		// We inline single-character matches for speed
 		if ( !$this->contains_expression($value) && \strlen( eval( 'return '. $value . ';' ) ) === 1 ) {
-			return $this->match_fail_conditional( '\substr($this->string,$this->pos,1) == '.$value,
+			return $this->match_fail_conditional( '\substr($this->string,$this->pos,1) === '.$value,
 				PHPBuilder::build()->l(
 					'$this->pos += 1;',
 					$this->set_text($value)

--- a/lib/hafriedlander/Peg/Compiler/Token/Option.php
+++ b/lib/hafriedlander/Peg/Compiler/Token/Option.php
@@ -21,7 +21,7 @@ class Option extends Token {
 			$code->l(
 				$opt->compile()->replace(array(
 					'MATCH' => 'MBREAK',
-					'FAIL' => NULL
+					'FAIL' => \null
 				)),
 				$this->restore($id)
 			);

--- a/lib/hafriedlander/Peg/Compiler/Token/Recurse.php
+++ b/lib/hafriedlander/Peg/Compiler/Token/Recurse.php
@@ -41,17 +41,17 @@ class Recurse extends Token {
 			);
 		}
 		else {
-			$debug_header = $debug_match = $debug_fail = NULL ;
+			$debug_header = $debug_match = $debug_fail = \null ;
 		}
 
 		return PHPBuilder::build()->l(
 			'$matcher = \'match_\'.'.$function.'; $key = $matcher; $pos = $this->pos;',
 			$debug_header,
-			'$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );',
-			$this->match_fail_conditional( '$subres !== FALSE',
+			'$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(\array_merge($stack, array($result))) ) );',
+			$this->match_fail_conditional( '$subres !== \false',
 				PHPBuilder::build()->l(
 					$debug_match,
-					$this->tag === FALSE ?
+					$this->tag === \false ?
 						'$this->store( $result, $subres );' :
 						'$this->store( $result, $subres, "'.$storetag.'" );'
 				),

--- a/lib/hafriedlander/Peg/Compiler/Token/Regex.php
+++ b/lib/hafriedlander/Peg/Compiler/Token/Regex.php
@@ -6,8 +6,8 @@ use hafriedlander\Peg\Compiler\PHPBuilder;
 
 class Regex extends Expressionable {
 	static function escape( $rx ) {
-		$rx = str_replace( "'", "\\'", $rx ) ;
-		$rx = str_replace( '\\\\', '\\\\\\\\', $rx ) ;
+		$rx = \str_replace( "'", "\\'", $rx ) ;
+		$rx = \str_replace( '\\\\', '\\\\\\\\', $rx ) ;
 		return $rx ;
 	}
 

--- a/lib/hafriedlander/Peg/Compiler/Token/Sequence.php
+++ b/lib/hafriedlander/Peg/Compiler/Token/Sequence.php
@@ -15,7 +15,7 @@ class Sequence extends Token {
 		foreach( $value as $token ) {
 			$code->l(
 				$token->compile()->replace(array(
-					'MATCH' => NULL,
+					'MATCH' => \null,
 					'FAIL' => 'FBREAK'
 				))
 			);

--- a/lib/hafriedlander/Peg/Compiler/Token/Terminal.php
+++ b/lib/hafriedlander/Peg/Compiler/Token/Terminal.php
@@ -6,11 +6,11 @@ use hafriedlander\Peg\Compiler\Token;
 
 abstract class Terminal extends Token {
 	function set_text( $text ) {
-		return $this->silent ? NULL : '$result["text"] .= ' . $text . ';';
+		return $this->silent ? \null : '$result["text"] .= ' . $text . ';';
 	}
 
 	protected function match_code( $value ) {
-		return $this->match_fail_conditional( '( $subres = $this->'.$this->type.'( '.$value.' ) ) !== FALSE',
+		return $this->match_fail_conditional( '( $subres = $this->'.$this->type.'( '.$value.' ) ) !== \false',
 			$this->set_text('$subres')
 		);
 	}

--- a/lib/hafriedlander/Peg/Compiler/Token/Whitespace.php
+++ b/lib/hafriedlander/Peg/Compiler/Token/Whitespace.php
@@ -10,6 +10,6 @@ class Whitespace extends Terminal {
 	/* Call recursion indirectly */
 	function match_code( $value ) {
 		$code = parent::match_code( '' ) ;
-		return $value ? $code->replace( array( 'FAIL' => NULL )) : $code ;
+		return $value ? $code->replace( array( 'FAIL' => \null )) : $code ;
 	}
 }

--- a/lib/hafriedlander/Peg/Parser/Basic.php
+++ b/lib/hafriedlander/Peg/Parser/Basic.php
@@ -101,6 +101,7 @@ class Basic {
 	}
 
 	function finalise( &$result ) {
+
 		foreach ($this->typestack($result['_matchrule']) as $type) {
 			$callback = array( $this, "{$type}__finalise" ) ;
 			if ( \is_callable( $callback ) ) {
@@ -113,8 +114,8 @@ class Basic {
 	}
 
 	function store ( &$result, $subres, $storetag = \null ) {
-		$result['text'] .= $subres['text'] ;
 
+		$result['text'] .= $subres['text'];
 		$storecalled = \false;
 
 		foreach ($this->typestack($result['_matchrule']) as $type) {
@@ -130,7 +131,6 @@ class Basic {
 				$storecalled = \true; break;
 			}
 		}
-
 		if ( $storetag && !$storecalled ) {
 			if ( !isset( $result[$storetag] ) ) $result[$storetag] = $subres ;
 			else {

--- a/lib/hafriedlander/Peg/Parser/Basic.php
+++ b/lib/hafriedlander/Peg/Parser/Basic.php
@@ -83,7 +83,10 @@ class Basic {
 	}
 
 	function construct( $matchrule, $name, $arguments = \null ) {
+
 		$result = array( '_matchrule' => $matchrule, 'name' => $name, 'text' => '' );
+		$result['offset'] = $this->pos;
+
 		if ($arguments) $result = array_merge($result, $arguments) ;
 
 		foreach ($this->typestack($matchrule) as $type) {

--- a/lib/hafriedlander/Peg/Parser/Basic.php
+++ b/lib/hafriedlander/Peg/Parser/Basic.php
@@ -16,27 +16,27 @@ class Basic {
 
 		$this->depth = 0 ;
 
-		$this->regexps = array() ;
+		$this->regexps = [] ;
 	}
 
 	function whitespace() {
-		$matched = preg_match( '/[ \t]+/', $this->string, $matches, PREG_OFFSET_CAPTURE, $this->pos ) ;
+		$matched = \preg_match( '/[ \t]+/', $this->string, $matches, \PREG_OFFSET_CAPTURE, $this->pos ) ;
 		if ( $matched && $matches[0][1] == $this->pos ) {
-			$this->pos += strlen( $matches[0][0] );
+			$this->pos += \strlen( $matches[0][0] );
 			return ' ' ;
 		}
-		return FALSE ;
+		return \false ;
 	}
 
 	function literal( $token ) {
 		/* Debugging: * / print( "Looking for token '$token' @ '" . substr( $this->string, $this->pos ) . "'\n" ) ; /* */
-		$toklen = strlen( $token ) ;
-		$substr = substr( $this->string, $this->pos, $toklen ) ;
+		$toklen = \strlen( $token ) ;
+		$substr = \substr( $this->string, $this->pos, $toklen ) ;
 		if ( $substr == $token ) {
 			$this->pos += $toklen ;
 			return $token ;
 		}
-		return FALSE ;
+		return \false ;
 	}
 
 	function rx( $rx ) {
@@ -45,7 +45,7 @@ class Basic {
 	}
 
 	function expression( $result, $stack, $value ) {
-		$stack[] = $result; $rv = false;
+		$stack[] = $result; $rv = \false;
 
 		/* Search backwards through the sub-expression stacks */
 		for ( $i = count($stack) - 1 ; $i >= 0 ; $i-- ) {
@@ -55,22 +55,22 @@ class Basic {
 
 			foreach ($this->typestack($node['_matchrule']) as $type) {
 				$callback = array($this, "{$type}_DLR{$value}");
-				if ( is_callable( $callback ) ) { $rv = call_user_func( $callback ) ; if ($rv !== FALSE) break; }
+				if ( is_callable( $callback ) ) { $rv = call_user_func( $callback ) ; if ($rv !== \false) break; }
 			}
 		}
 
-		if ($rv === false) $rv = @$this->$value;
-		if ($rv === false) $rv = @$this->$value();
+		if ($rv === \false) $rv = @$this->$value;
+		if ($rv === \false) $rv = @$this->$value();
 
 		return is_array($rv) ? $rv['text'] : ($rv ? $rv : '');
 	}
 
 	function packhas( $key, $pos ) {
-		return false ;
+		return \false ;
 	}
 
 	function packread( $key, $pos ) {
-		throw new \Exception('PackRead after PackHas=>false in Parser.php') ;
+		throw new \Exception('PackRead after PackHas=>\false in Parser.php') ;
 	}
 
 	function packwrite( $key, $pos, $res ) {
@@ -82,13 +82,13 @@ class Basic {
 		return $this->$prop;
 	}
 
-	function construct( $matchrule, $name, $arguments = null ) {
+	function construct( $matchrule, $name, $arguments = \null ) {
 		$result = array( '_matchrule' => $matchrule, 'name' => $name, 'text' => '' );
 		if ($arguments) $result = array_merge($result, $arguments) ;
 
 		foreach ($this->typestack($matchrule) as $type) {
 			$callback = array( $this, "{$type}__construct" ) ;
-			if ( is_callable( $callback ) ) {
+			if ( \is_callable( $callback ) ) {
 				call_user_func_array( $callback, array( &$result ) ) ;
 				break;
 			}
@@ -100,7 +100,7 @@ class Basic {
 	function finalise( &$result ) {
 		foreach ($this->typestack($result['_matchrule']) as $type) {
 			$callback = array( $this, "{$type}__finalise" ) ;
-			if ( is_callable( $callback ) ) {
+			if ( \is_callable( $callback ) ) {
 				call_user_func_array( $callback, array( &$result ) ) ;
 				break;
 			}
@@ -109,22 +109,22 @@ class Basic {
 		return $result ;
 	}
 
-	function store ( &$result, $subres, $storetag = NULL ) {
+	function store ( &$result, $subres, $storetag = \null ) {
 		$result['text'] .= $subres['text'] ;
 
-		$storecalled = false;
+		$storecalled = \false;
 
 		foreach ($this->typestack($result['_matchrule']) as $type) {
 			$callback = array( $this, $storetag ? "{$type}_{$storetag}" : "{$type}_{$subres['name']}" ) ;
-			if ( is_callable( $callback ) ) {
+			if ( \is_callable( $callback ) ) {
 				call_user_func_array( $callback, array( &$result, $subres ) ) ;
-				$storecalled = true; break;
+				$storecalled = \true; break;
 			}
 
 			$globalcb = array( $this, "{$type}_STR" ) ;
-			if ( is_callable( $globalcb ) ) {
+			if ( \is_callable( $globalcb ) ) {
 				call_user_func_array( $globalcb, array( &$result, $subres ) ) ;
-				$storecalled = true; break;
+				$storecalled = \true; break;
 			}
 		}
 

--- a/lib/hafriedlander/Peg/Parser/CachedRegexp.php
+++ b/lib/hafriedlander/Peg/Parser/CachedRegexp.php
@@ -11,30 +11,47 @@ namespace hafriedlander\Peg\Parser;
  *  the bracket if a failed match + restore has moved the current position backwards - so we have to check that too.
  */
 class CachedRegexp {
-	function __construct( $parser, $rx ) {
-		$this->parser = $parser ;
-		$this->rx = $rx . 'Sx' ;
 
-		$this->matches = \null ;
-		$this->match_pos = \null ; // \null is no-match-to-end-of-string, unless check_pos also == \null, in which case means undefined
-		$this->check_pos = \null ;
+	const DEFAULT_MODIFIERS = [
+		"S", // Extra analysis is performed.
+		"x", // Ignore extra whitespace.
+	];
+
+	function __construct($parser, $rx) {
+
+		$this->parser = $parser;
+
+		$modifiers = \str_split(\substr($rx, \strrpos($rx, '/') + 1));
+		$this->rx = $rx . \implode('', self::DEFAULT_MODIFIERS + $modifiers);
+
+		$this->matches = \null;
+		$this->match_pos = \null; // \null is no-match-to-end-of-string, unless check_pos also == \null, in which case means undefined.
+		$this->check_pos = \null;
+
 	}
 
 	function match() {
-		$current_pos = $this->parser->pos ;
-		$dirty = $this->check_pos === \null || $this->check_pos > $current_pos || ( $this->match_pos !== \null && $this->match_pos < $current_pos ) ;
+		$current_pos = $this->parser->pos;
+		$dirty = $this->check_pos === \null || $this->check_pos > $current_pos || ($this->match_pos !== \null && $this->match_pos < $current_pos);
 
-		if ( $dirty ) {
-			$this->check_pos = $current_pos ;
-			$matched = \preg_match( $this->rx, $this->parser->string, $this->matches, \PREG_OFFSET_CAPTURE, $this->check_pos) ;
-			if ( $matched ) $this->match_pos = $this->matches[0][1] ; else $this->match_pos = \null ;
+		if ($dirty) {
+
+			$this->check_pos = $current_pos;
+			$matched = \preg_match($this->rx, $this->parser->string, $this->matches, \PREG_OFFSET_CAPTURE, $this->check_pos);
+
+			if ($matched) {
+				$this->match_pos = $this->matches[0][1];
+			} else {
+				$this->match_pos = \null;
+			}
+
 		}
 
-		if ( $this->match_pos === $current_pos ) {
-			$this->parser->pos += strlen( $this->matches[0][0] );
-			return $this->matches[0][0] ;
+		if ($this->match_pos === $current_pos) {
+			$this->parser->pos += strlen($this->matches[0][0]);
+			return $this->matches[0][0];
 		}
 
-		return \false ;
+		return \false;
 	}
 }

--- a/lib/hafriedlander/Peg/Parser/CachedRegexp.php
+++ b/lib/hafriedlander/Peg/Parser/CachedRegexp.php
@@ -17,12 +17,15 @@ class CachedRegexp {
 		"x", // Ignore extra whitespace.
 	];
 
+	public $modifiers = [];
+
 	function __construct($parser, $rx) {
 
 		$this->parser = $parser;
 
 		$modifiers = \str_split(\substr($rx, \strrpos($rx, '/') + 1));
-		$this->rx = $rx . \implode('', self::DEFAULT_MODIFIERS + $modifiers);
+		$this->modifiers = array_unique(array_merge(self::DEFAULT_MODIFIERS, $modifiers));
+		$this->rx = $rx . \implode('', $this->modifiers);
 
 		$this->matches = \null;
 		$this->match_pos = \null; // \null is no-match-to-end-of-string, unless check_pos also == \null, in which case means undefined.

--- a/lib/hafriedlander/Peg/Parser/CachedRegexp.php
+++ b/lib/hafriedlander/Peg/Parser/CachedRegexp.php
@@ -15,19 +15,19 @@ class CachedRegexp {
 		$this->parser = $parser ;
 		$this->rx = $rx . 'Sx' ;
 
-		$this->matches = NULL ;
-		$this->match_pos = NULL ; // NULL is no-match-to-end-of-string, unless check_pos also == NULL, in which case means undefined
-		$this->check_pos = NULL ;
+		$this->matches = \null ;
+		$this->match_pos = \null ; // \null is no-match-to-end-of-string, unless check_pos also == \null, in which case means undefined
+		$this->check_pos = \null ;
 	}
 
 	function match() {
 		$current_pos = $this->parser->pos ;
-		$dirty = $this->check_pos === NULL || $this->check_pos > $current_pos || ( $this->match_pos !== NULL && $this->match_pos < $current_pos ) ;
+		$dirty = $this->check_pos === \null || $this->check_pos > $current_pos || ( $this->match_pos !== \null && $this->match_pos < $current_pos ) ;
 
 		if ( $dirty ) {
 			$this->check_pos = $current_pos ;
-			$matched = preg_match( $this->rx, $this->parser->string, $this->matches, PREG_OFFSET_CAPTURE, $this->check_pos) ;
-			if ( $matched ) $this->match_pos = $this->matches[0][1] ; else $this->match_pos = NULL ;
+			$matched = \preg_match( $this->rx, $this->parser->string, $this->matches, \PREG_OFFSET_CAPTURE, $this->check_pos) ;
+			if ( $matched ) $this->match_pos = $this->matches[0][1] ; else $this->match_pos = \null ;
 		}
 
 		if ( $this->match_pos === $current_pos ) {
@@ -35,6 +35,6 @@ class CachedRegexp {
 			return $this->matches[0][0] ;
 		}
 
-		return FALSE ;
+		return \false ;
 	}
 }

--- a/lib/hafriedlander/Peg/Parser/ConservativePackrat.php
+++ b/lib/hafriedlander/Peg/Parser/ConservativePackrat.php
@@ -11,7 +11,7 @@ namespace hafriedlander\Peg\Parser;
  */
 class ConservativePackrat extends Basic {
 	function packhas( $key, $pos ) {
-		return isset( $this->packres[$key] ) && $this->packres[$key] !== NULL ;
+		return isset( $this->packres[$key] ) && $this->packres[$key] !== \null ;
 	}
 
 	function packread( $key, $pos ) {
@@ -25,7 +25,7 @@ class ConservativePackrat extends Basic {
 			$this->packpos[$key] = $this->pos ;
 		}
 		else {
-			$this->packres[$key] = NULL ;
+			$this->packres[$key] = \null ;
 		}
 		return $res ;
 	}

--- a/lib/hafriedlander/Peg/Parser/FalseOnlyPackrat.php
+++ b/lib/hafriedlander/Peg/Parser/FalseOnlyPackrat.php
@@ -3,7 +3,7 @@
 namespace hafriedlander\Peg\Parser;
 
 /**
- * FalseOnlyPackrat only remembers which results where false. Experimental.
+ * FalseOnlyPackrat only remembers which results where \false. Experimental.
  *
  * @author Hamish Friedlander
  */
@@ -11,8 +11,8 @@ class FalseOnlyPackrat extends Basic {
 	function __construct( $string ) {
 		parent::__construct( $string ) ;
 
-		$this->packstatebase = str_repeat( '.', strlen( $string ) ) ;
-		$this->packstate = array() ;
+		$this->packstatebase = \str_repeat( '.', \strlen( $string ) ) ;
+		$this->packstate = [] ;
 	}
 
 	function packhas( $key, $pos ) {
@@ -20,13 +20,13 @@ class FalseOnlyPackrat extends Basic {
 	}
 
 	function packread( $key, $pos ) {
-		return FALSE ;
+		return \false ;
 	}
 
 	function packwrite( $key, $pos, $res ) {
 		if ( !isset( $this->packstate[$key] ) ) $this->packstate[$key] = $this->packstatebase ;
 
-		if ( $res === FALSE ) {
+		if ( $res === \false ) {
 			$this->packstate[$key][$pos] = 'F' ;
 		}
 

--- a/lib/hafriedlander/Peg/Parser/Packrat.php
+++ b/lib/hafriedlander/Peg/Parser/Packrat.php
@@ -15,12 +15,12 @@ class Packrat extends Basic {
 	function __construct( $string ) {
 		parent::__construct( $string ) ;
 
-		$max = unpack( 'N', "\x00\xFD\xFF\xFF" ) ;
-		if ( strlen( $string ) > $max[1] ) user_error( 'Attempting to parse string longer than Packrat Parser can handle', E_USER_ERROR ) ;
+		$max = \unpack( 'N', "\x00\xFD\xFF\xFF" ) ;
+		if ( \strlen( $string ) > $max[1] ) user_error( 'Attempting to parse string longer than Packrat Parser can handle', E_USER_ERROR ) ;
 
-		$this->packstatebase = str_repeat( "\xFF", strlen( $string )*3 ) ;
-		$this->packstate = array() ;
-		$this->packres = array() ;
+		$this->packstatebase = \str_repeat( "\xFF", \strlen( $string )*3 ) ;
+		$this->packstate = [] ;
+		$this->packres = [] ;
 	}
 
 	function packhas( $key, $pos ) {
@@ -30,9 +30,9 @@ class Packrat extends Basic {
 
 	function packread( $key, $pos ) {
 		$pos *= 3 ;
-		if ( $this->packstate[$key][$pos] == "\xFE" ) return FALSE ;
+		if ( $this->packstate[$key][$pos] == "\xFE" ) return \false ;
 
-		$this->pos = ord($this->packstate[$key][$pos]) << 16 | ord($this->packstate[$key][$pos+1]) << 8 | ord($this->packstate[$key][$pos+2]) ;
+		$this->pos = \ord($this->packstate[$key][$pos]) << 16 | \ord($this->packstate[$key][$pos+1]) << 8 | \ord($this->packstate[$key][$pos+2]) ;
 		return $this->packres["$key:$pos"] ;
 	}
 
@@ -41,8 +41,8 @@ class Packrat extends Basic {
 
 		$pos *= 3 ;
 
-		if ( $res !== FALSE ) {
-			$i = pack( 'N', $this->pos ) ;
+		if ( $res !== \false ) {
+			$i = \pack( 'N', $this->pos ) ;
 
 			$this->packstate[$key][$pos]   = $i[1] ;
 			$this->packstate[$key][$pos+1] = $i[2] ;

--- a/lib/hafriedlander/Peg/Parser/Packrat.php
+++ b/lib/hafriedlander/Peg/Parser/Packrat.php
@@ -6,16 +6,25 @@ namespace hafriedlander\Peg\Parser;
  * By inheriting from Packrat instead of Parser, the parser will run in linear time (instead of exponential like
  * Parser), but will require a lot more memory, since every match-attempt at every position is memorised.
  *
- * We now use a string as a byte-array to store position information rather than a straight array for memory reasons. This
- * means there is a (roughly) 8MB limit on the size of the string we can parse
+ * Originally a single string was used as a storage for memoizing parser results.
+ * This approach is now abandoned in favor of true PHP arrays, which now seem to be a better choice, since PHP 7.0
+ * optimized internal workings of PHP arrays. It seems that using array as a storage actually has lower memory
+ * footprint than the original "string" implementation.
  *
+ * This refactoring also significantly simplified the packrat parser's code.
+ *
+ * @author Premysl Karbula
  * @author Hamish Friedlander
  */
 class Packrat extends Basic {
-	function __construct( $string ) {
-		parent::__construct( $string ) ;
+
+	function __construct($string) {
+
+		parent::__construct($string) ;
+
 		$this->packres = [];
 		$this->packpos = [];
+
 	}
 
 	function packhas($key, $pos) {
@@ -25,7 +34,7 @@ class Packrat extends Basic {
 	function packread($key, $pos) {
 
 		if (!isset($this->packres[$key][$pos])) {
-			return false;
+			return \false;
 		}
 
 		$this->pos = $this->packpos[$key][$pos];
@@ -33,16 +42,16 @@ class Packrat extends Basic {
 
 	}
 
-	function packwrite($key, $pos, $res) {
+	function packwrite($key, $pos, $result) {
 
-		if ($res !== \false) {
-			$this->packres[$key][$pos] = $res;
+		if ($result !== \false) {
+			$this->packres[$key][$pos] = $result;
 			$this->packpos[$key][$pos] = $this->pos;
 		} else {
-			$this->packres[$key][$pos] = false;
+			$this->packres[$key][$pos] = \false;
 		}
 
-		return $res;
+		return $result;
 
 	}
 }

--- a/tests/CachedRegexpTest.php
+++ b/tests/CachedRegexpTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use \hafriedlander\Peg\Parser\CachedRegexp;
+
+class CachedRegexpTest extends \PHPUnit\Framework\TestCase {
+
+	public function testModifiers() {
+
+        $fakeParser = (object) [
+            'string' => '',
+            'pos' => 0,
+        ];
+
+        $modifiers = ["x", "y", "z"];
+        $rx = "/[abc]{3}/" . implode('', $modifiers);
+        $r = new CachedRegexp($fakeParser, $rx);
+
+        // Test that CachedRegexp correctly parses regex modifiers passed in.
+        // Reindex with array_values() because keys matter to assertSame(), too,
+        // although we don't really care.
+        $this->assertSame(["S", "x", "y", "z"], array_values($r->modifiers));
+
+	}
+
+	public function testMatching() {
+
+        $fakeParser = (object) [
+            'string' => 'xyzabcdef',
+            'pos' => 0,
+        ];
+
+        $rx = "/[abc]{3}/";
+        $r = new CachedRegexp($fakeParser, $rx);
+
+        // False, because the regex doesn't match the 'string' exactly at the 'pos' offset.
+        $this->assertFalse($r->match());
+
+        $rx = "/[xyz]{3}/";
+        $r = new CachedRegexp($fakeParser, $rx);
+
+        // If regex matches the 'string' at the 'pos', the match() method returns the matched string.
+        $this->assertSame('xyz', $r->match());
+
+	}
+
+
+}

--- a/tests/ParserInheritanceTest.php
+++ b/tests/ParserInheritanceTest.php
@@ -3,9 +3,9 @@
 require_once "ParserTestBase.php";
 
 class ParserInheritanceTest extends ParserTestBase {
-	
+
 	public function testBasicInheritance() {
-		
+
 		$parser = $this->buildParser('
 			/*!* BasicInheritanceTestParser
 			Foo: "a"
@@ -20,9 +20,9 @@ class ParserInheritanceTest extends ParserTestBase {
 		$this->assertFalse($parser->matches('Bar', 'b'));
 	}
 
-	
+
 	public function testBasicInheritanceConstructFallback() {
-		
+
 		$parser = $this->buildParser('
 			/*!* BasicInheritanceConstructFallbackParser
 			Foo: "a"
@@ -33,10 +33,10 @@ class ParserInheritanceTest extends ParserTestBase {
 
 		$res = $parser->match('Foo', 'a');
 		$this->assertEquals($res['test'], 'test');
-		
+
 		$res = $parser->match('Bar', 'a');
 		$this->assertEquals($res['test'], 'test');
-		
+
 		$parser = $this->buildParser('
 			/*!* BasicInheritanceConstructFallbackParser2
 			Foo: "a"
@@ -50,16 +50,16 @@ class ParserInheritanceTest extends ParserTestBase {
 		$this->assertArrayHasKey('testa', $res);
 		$this->assertEquals($res['testa'], 'testa');
 		$this->assertArrayNotHasKey('testb', $res);
-		
+
 		$res = $parser->match('Bar', 'a');
 		$this->assertArrayHasKey('testb', $res);
 		$this->assertEquals($res['testb'], 'testb');
 		$this->assertArrayNotHasKey('testa', $res);
-		
+
 	}
 
 	public function testBasicInheritanceStoreFallback() {
-		
+
 		$parser = $this->buildParser('
 			/*!* BasicInheritanceStoreFallbackParser
 			Foo: Pow:"a"
@@ -70,10 +70,10 @@ class ParserInheritanceTest extends ParserTestBase {
 
 		$res = $parser->match('Foo', 'a');
 		$this->assertEquals($res['test'], 'test');
-		
+
 		$res = $parser->match('Bar', 'a');
 		$this->assertEquals($res['test'], 'test');
-		
+
 		$parser = $this->buildParser('
 			/*!* BasicInheritanceStoreFallbackParser2
 			Foo: Pow:"a" Zap:"b"
@@ -89,7 +89,7 @@ class ParserInheritanceTest extends ParserTestBase {
 		$this->assertArrayHasKey('testa', $res);
 		$this->assertEquals($res['testa'], 'testa');
 		$this->assertArrayNotHasKey('testb', $res);
-		
+
 		$res = $parser->match('Bar', 'ab');
 		$this->assertArrayHasKey('testb', $res);
 		$this->assertEquals($res['testb'], 'testb');
@@ -113,11 +113,10 @@ class ParserInheritanceTest extends ParserTestBase {
 			Baz extends Foo; A => ""
 			*/
 		');
-		
+
 		$parser->assertMatches('Foo', 'ab');
 		$parser->assertMatches('Bar', 'aa');
 		$parser->assertMatches('Baz', 'b');
 	}
-	
-	
+
 }

--- a/tests/ParserPackratTest.php
+++ b/tests/ParserPackratTest.php
@@ -1,0 +1,32 @@
+<?php
+
+require_once "ParserTestBase.php";
+
+class PackratParserSyntaxTest extends ParserTestBase {
+
+	public function testBasicRuleSyntax() {
+
+		$parser = $this->buildParser('
+			/*!*
+			String: /("(.|\n)*?"|\'(.|\n)*?\')/
+			Number: /-?\d+(\.\d+)?/
+			Bool: "true" | "false"
+			Regex: "/" /(\\\/|[^\/])+/ "/"
+
+			Literal: Number | String | Bool | Regex
+			AddOperator: "+" | "-"
+			MultiplyOperator: "*" | "/"
+
+			Add: operands:Factor ( > ops:AddOperator > operands:Factor)*
+			Factor: operands:Literal ( > ops:MultiplyOperator > operands:Literal)*
+
+			Expression: Add
+			*/
+		', 'Packrat');
+
+		$parser->assertMatches('Expression', '1 + 2 * 3 + 4 + 4 + 4 + 4 + 4 / 5 - 6 + 7 * 8 - 9');
+		$parser->assertDoesntMatch('Expression', 'variables + do + not + exist');
+
+	}
+
+}

--- a/tests/ParserTestBase.php
+++ b/tests/ParserTestBase.php
@@ -1,11 +1,11 @@
 <?php
 
-require_once dirname(__DIR__).'/autoloader.php';
+require_once __DIR__ .'/../autoloader.php';
 
 use hafriedlander\Peg;
 
 class ParserTestWrapper {
-	
+
 	function __construct($testcase, $class){
 		$this->testcase = $testcase;
 		$this->class = $class;
@@ -22,27 +22,27 @@ class ParserTestWrapper {
 	function match($method, $string, $allowPartial = false){
 		$class = $this->class;
 		$func = $this->function_name('match_'.$method);
-		
+
 		$parser = new $class($string);
 		$res = $parser->$func();
 		return ($allowPartial || $parser->pos == strlen($string)) ? $res : false;
 	}
-	
+
 	function matches($method, $string, $allowPartial = false){
 		return $this->match($method, $string, $allowPartial) !== false;
 	}
-	
+
 	function assertMatches($method, $string, $message = null){
 		$this->testcase->assertTrue($this->matches($method, $string), $message ? $message : "Assert parser method $method matches string $string");
 	}
-	
+
 	function assertDoesntMatch($method, $string, $message = null){
 		$this->testcase->assertFalse($this->matches($method, $string), $message ? $message : "Assert parser method $method doesn't match string $string");
 	}
 }
 
-class ParserTestBase extends PHPUnit_Framework_TestCase {
-	
+class ParserTestBase extends \PHPUnit\Framework\TestCase {
+
 	function buildParser($parser) {
 		$class = 'Parser'.sha1($parser);
 

--- a/tests/ParserTestBase.php
+++ b/tests/ParserTestBase.php
@@ -1,54 +1,59 @@
 <?php
 
-require_once __DIR__ .'/../autoloader.php';
+require_once __DIR__ . '/../autoloader.php';
 
 use hafriedlander\Peg;
 
 class ParserTestWrapper {
 
-	function __construct($testcase, $class){
+	function __construct($testcase, $class) {
 		$this->testcase = $testcase;
 		$this->class = $class;
 	}
 
 	function function_name( $str ) {
-		$str = preg_replace( '/-/', '_', $str ) ;
-		$str = preg_replace( '/\$/', 'DLR', $str ) ;
-		$str = preg_replace( '/\*/', 'STR', $str ) ;
-		$str = preg_replace( '/[^\w]+/', '', $str ) ;
-		return $str ;
+		$str = preg_replace( '/-/', '_', $str );
+		$str = preg_replace( '/\$/', 'DLR', $str );
+		$str = preg_replace( '/\*/', 'STR', $str );
+		$str = preg_replace( '/[^\w]+/', '', $str );
+		return $str;
 	}
 
-	function match($method, $string, $allowPartial = false){
+	function match($method, $string, $allowPartial = false) {
 		$class = $this->class;
-		$func = $this->function_name('match_'.$method);
+		$func = $this->function_name('match_' . $method);
 
 		$parser = new $class($string);
 		$res = $parser->$func();
-		return ($allowPartial || $parser->pos == strlen($string)) ? $res : false;
+		return ($allowPartial || $parser->pos === strlen($string)) ? $res : false;
 	}
 
-	function matches($method, $string, $allowPartial = false){
+	function matches($method, $string, $allowPartial = false) {
 		return $this->match($method, $string, $allowPartial) !== false;
 	}
 
-	function assertMatches($method, $string, $message = null){
+	function assertMatches($method, $string, $message = null) {
 		$this->testcase->assertTrue($this->matches($method, $string), $message ? $message : "Assert parser method $method matches string $string");
 	}
 
-	function assertDoesntMatch($method, $string, $message = null){
+	function assertDoesntMatch($method, $string, $message = null) {
 		$this->testcase->assertFalse($this->matches($method, $string), $message ? $message : "Assert parser method $method doesn't match string $string");
 	}
 }
 
 class ParserTestBase extends \PHPUnit\Framework\TestCase {
 
-	function buildParser($parser) {
-		$class = 'Parser'.sha1($parser);
+	function buildParser($grammar, $baseClass = 'Basic') {
 
-		// echo ParserCompiler::compile("class $class extends Parser {\n $parser\n}") . "\n\n\n";
-		eval(Peg\Compiler::compile("class $class extends hafriedlander\Peg\Parser\Basic {\n $parser\n}"));
+		$class = 'Parser_' . md5(uniqid());
+		eval(Peg\Compiler::compile("
+			class $class extends hafriedlander\Peg\Parser\\$baseClass {
+				$grammar
+			}
+		"));
+
 		return new ParserTestWrapper($this, $class);
+
 	}
 
 }


### PR DESCRIPTION
- (Micro) **Optimization**: Using native PHP constants and functions with absolute namespace is slightly faster *(changed in generated, too)*.
- (Micro) **Optimization**: Use strict comparisons where possible *(even in generated code)*.
- **Fix**: Another catastrofic backtracking problem *(happened to me during compilation of a larger grammar)* avoided by simplifying regex that searches for grammar definitions.
- **Fix**: Fixed tests for PHPUnit 6.5 *(which is now also added as `dev` dependency to `composer.json`)*
- **Fix, Optimization**: *Packrat parser overhaul.* Simplified logic using arrays instead of a string. When I tested this, arrays ultimately seemed to be more fit for the job, *memory-wise* *(I suspect array optimizations in Zend engine in PHP 7.0)*. 
